### PR TITLE
ingress.class: "nginx"

### DIFF
--- a/.kube/ingress.yaml
+++ b/.kube/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mcs-kubernetes-project
+  annotations:
+    # use the shared ingress-nginx
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - http:


### PR DESCRIPTION
Hi, Pavel,

sorry for disturbing, but there is a client who use your examples and he found, that the example doesn't work with k8s v22, asking us to fix it.

there is additional information about the annotation
https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/
```
When you apply this yaml, 2 ingress resources will be created managed by the ingress-nginx instance. Nginx is configured to automatically discover all ingress with the kubernetes.io/ingress.class: "nginx" annotation or where ingressClassName: nginx is present. Please note that the ingress resource should be placed inside the same namespace of the backend resource.
```